### PR TITLE
ci: fix path to uv-sync.sh when running tests from component src dirs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,9 +94,9 @@ jobs:
             fi
           fi
           # Prepare venv and deps from repo root
-          cd ..
+          cd ../..
           uv venv
           ./scripts/uv-sync.sh --all
           cd - >/dev/null
           # Run tests
-          ../.venv/bin/python -m pytest -v
+          ../../.venv/bin/python -m pytest -v


### PR DESCRIPTION
fix ci