### PR TITLE
chore: refresh AGENTS guide and update dependencies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,102 +1,158 @@
-# Repository Guidelines
+# AGENTS Guide: light-score
 
-## Architecture & Data Flow
+This file is for autonomous coding agents working in this repository.
+It captures the build/lint/test workflow and the coding conventions observed in code + config.
 
-- Three Python services: FastAPI API in `backend/`, Flask UI in `frontend/`, and ESPN parsing utilities in `functions/`.
-- Weekly flow: `functions/src/main.py` fetches ESPN standings with `EspnClient`, writes `backend/src/data/standings_cache.json`; backend serves cached standings and live ESPN snapshots; frontend renders scoreboard + standings using backend APIs.
-- Backend endpoints in `backend/src/main.py` call ESPN (`httpx`) and expose `/games/weekly`, `/games/weekly/context`, `/games/weekly/navigation`, `/standings`, `/standings/live`, `/teams`, and `/playoffs/bracket`.
-- Frontend `frontend/src/app.py` calls backend via `requests` (respect `BACKEND_URL`) and templates in `frontend/src/templates` for Teletext-style UI.
+## Rule Sources Checked
 
-## Project Structure & Module Organization
+- `.cursor/rules/`: not present.
+- `.cursorrules`: not present.
+- `.github/copilot-instructions.md`: not present.
+- Therefore, follow this file + repository code/config as the authoritative guidance.
 
-- `backend/src` hosts the FastAPI service (`main.py` entrypoint); add domain modules under descriptive subpackages and keep JSON caches in `data/`.
-- `frontend/src` contains the Flask UI with `templates/` and `static/`; route helpers live beside the app factory.
-- `functions/src` holds ESPN parsing jobs; trigger ad-hoc refreshes with `python functions/src/main.py`.
-- Co-locate Python unit tests under each `src/utest/` package; store E2E Playwright tests in `e2e/tests/`. Reference operational notes in `docs/`, automation in `scripts/`, and infrastructure in `terraform/`.
+## Architecture Snapshot
 
-## Build, Test, and Development Commands
+- Monorepo with three Python services and one TypeScript E2E test project.
+- `backend/`: FastAPI API (`backend/src/main.py`) for games, standings, teams, playoffs.
+- `frontend/`: Flask server-rendered UI (`frontend/src/app.py`, Jinja templates in `frontend/src/templates`).
+- `functions/`: ESPN parsing/ingestion utilities writing standings cache.
+- `e2e/`: Playwright + TypeScript tests against frontend (and local backend when available).
+- Shared tooling lives at repo root: `justfile`, root `pyproject.toml`, `.venv` via `uv`.
 
-- Use uv-managed venv: `just dev-setup` creates `.venv` and syncs deps across all subprojects.
-- Containers run via Podman by default: `just up` starts FastAPI (`:8000`) + Flask (`:5000`); set `DOCKER=docker` if needed.
-- **Mock mode**: `just mock-up` starts services with `MOCK_ESPN=true` for testing with fixture data (playoffs, standings) without live ESPN calls.
-- `just build-images` rebuilds when dependencies shift; `just down` stops containers.
-- Tests fan out per package through `just test` which runs pytest in `backend/src/utest`, `frontend/src/utest`, `functions/src/utest` with the root `.venv`.
-- `just ci` runs lint + types + tests in one pass.
-- Linting/formatting uses Ruff (`just lint`, `just fmt`); types via `just ty` (ty check); `just security` runs Bandit and pip-audit; `just health` performs a quick API smoke.
+## Environment & Setup
 
-### E2E Testing Commands (Playwright/TypeScript)
+- Python: 3.13+ required (`requires-python = ">=3.13"`).
+- Package/env manager: `uv`.
+- Primary setup command:
 
-- E2E tests live in `e2e/tests/` using Playwright with TypeScript; run with `just test-e2e` (requires services up via `just up`).
-- `just lint-e2e` runs ESLint, `just fmt-e2e` formats with Prettier, `just ty-e2e` runs TypeScript checks.
-- `just ci-e2e` runs the full E2E CI pipeline (lint + ty + test).
-- E2E tests use `bun` as the package manager; dependencies are installed automatically on first run.
+```bash
+just dev-setup
+source .venv/bin/activate
+```
 
-## Backend Patterns (`backend/src/main.py`)
+- Sync deps after changes: `just sync`.
+- Container engine defaults to Podman; override with Docker when needed:
 
-- `_get_weekly_games` caches ESPN scoreboard responses for `_GAMES_TTL_SECONDS` (60s); always propagate stale cache when ESPN fails instead of raising new errors.
-- Game payloads must set Finnish timezone helpers: `start_time_finnish`, `start_date_time_finnish`, `game_time`; tests assert new fields even when `None` (`test_weekly_games_timezone_fields`).
-- Navigation helpers (`get_season_navigation`, `/games/weekly/navigation`) enforce NFL week boundaries; keep transitions synced with tests in `backend/src/utest/test_navigation.py`.
-- `/standings` serves the local cache file; `/standings/live` wraps `_get_live_standings` with a 5-minute TTL and defensive fallbacks. Reuse `_extract_minimal_standings` for normalized rows `{team,wins,losses,ties,division}`.
-- When extending HTTP access, prefer `httpx` (already patched in tests). Mock `httpx.get` in unit tests to avoid live ESPN calls (`backend/src/utest/test_live_standings.py`).
+```bash
+just --set docker docker up
+```
 
-## Frontend Patterns (`frontend/src/app.py`)
+## Build / Run Commands
 
-- Flask route `/` fetches backend data, splits games into history/live/upcoming, and renders Teletext HTML. Keep all new template data serializable and ready for Jinja loops.
-- Respect network fallbacks: on `requests` errors, the page renders `home_no_api.html`; keep error handling broad enough to avoid crashing the UI.
-- Navigation links come from backend `/games/weekly/navigation`; maintain param naming (`seasonType` camelCase) to match backend models and FastAPI query parsing.
-- Static assets like `teletext.css` and `favicon.svg` are served from `frontend/src/static/`; the favicon is a dynamically generated SVG to match the retro theme.
-## Functions / Data Ingestion (`functions/src`)
+- Build containers: `just build-images`.
+- Start services: `just up` (backend `:8000`, frontend `:5000`).
+- Stop services: `just down`.
+- Tail logs: `just logs`.
+- Quick health check: `just health`.
+- Mock data mode (no live ESPN dependency): `just mock-up`.
 
-- `standings_parser.py` converts ESPN JSON into `ConferenceGroup` + `TeamStandingInfo` via `find_first` condition helpers; reuse these when parsing new stats to avoid duplicating key lookups.
-- `save_standings_cache` writes the lightweight standings list consumed by backend tests; ensure parsers keep this minimal schema stable.
-- Network access in functions uses async `httpx.AsyncClient`; async context manager handles cleanup—mirror this pattern for new API calls.
+## Lint / Format / Typecheck Commands
 
-## Coding Style & Naming Conventions
+- Python lint: `just lint` (`ruff check .`).
+- Python format: `just fmt` (`ruff format .`).
+- Python type checks: `just ty` (`ty check .`).
+- Full Python CI bundle: `just ci` (lint + types + unit tests).
+- Security checks: `just security` (Bandit + pip-audit).
 
-- Python 3.13+ with uv-managed virtualenv; use absolute imports and module-level constants for shared configuration.
-- Follow Ruff defaults: four-space indentation, 99-character lines, snake_case modules, and descriptive function names.
-- Name FastAPI paths with nouns (`/scores`, `/standings`) and align Flask templates with their routes (`templates/scores.html`).
-- Run `just fmt` before committing to keep formatting clean.
-- E2E tests use TypeScript with Playwright; follow `<feature>.spec.ts` naming convention.
+## Python Test Commands
 
-## Testing Guidelines
+- All Python unit tests: `just test`.
+- Backend-only suite:
 
-### Python Unit Tests
+```bash
+cd backend/src && ../../.venv/bin/python -m pytest utest/ -v
+```
 
-- Write pytest tests named `test_*` inside the closest `src/utest/`; isolate fixtures under `utest/fixtures/`.
-- Store new unit tests alongside code under the respective `utest/` package; prefer patching network calls and using fixture builders like `_scoreboard_payload()` from `backend/src/utest/test_main.py`.
-- Mock external HTTP calls with `httpx` mock transports or local sample payloads—no live ESPN traffic in CI.
-- Tests assume Helsinki timezone formatting helper functions (`format_finnish_time`, `format_finnish_date_time`) remain resilient to malformed inputs; keep try/except guards when modifying them.
-- Keep ESPN URLs configurable only where necessary; hard-coded constants live near the call sites so that tests can patch them.
-- Keep tests deterministic and fast; ensure `just test` and `just ci` pass locally before pushing.
+- Other service suites use the same pattern from project root:
+  - `cd frontend/src && ../../.venv/bin/python -m pytest utest/ -v`
+  - `cd functions/src && ../../.venv/bin/python -m pytest utest/ -v`
 
-### E2E Tests (Playwright)
+- Run a single test file (example):
 
-- Store E2E tests in `e2e/tests/` with `.spec.ts` extension; group by feature (e.g., `home.spec.ts`, `site-navigation.spec.ts`).
-- API-specific tests live in `e2e/tests/api/` (e.g., `backend.spec.ts`, `integration.spec.ts`); shared utilities in `e2e/tests/utils/`.
-- Use role-based locators (`getByRole`, `getByLabel`, `getByText`) for resilience and accessibility.
-- Use auto-retrying web-first assertions (`await expect(locator).toHaveText()`); avoid hard-coded waits.
-- Tests can run against different environments via `SERVICE_URL` (frontend) and `BACKEND_URL` env vars; local defaults to `localhost:5000` and `localhost:8000`.
-- Run `just test-e2e` with services up (`just up`) before pushing UI changes.
+```bash
+cd backend/src && ../../.venv/bin/python -m pytest utest/test_navigation.py -v
+```
 
-## Branching & Pull Request Workflow
+- Run a single test function (example):
 
-- **Never push directly to `main`.** All changes must go through a feature branch and a pull request (PR).
-- Create a descriptively named branch from `main` using conventional prefixes: `feat/`, `fix/`, `chore/`, `docs/` (e.g., `fix/ci-uv-venv-cache`, `chore/dependabot-bumps`).
-- Use Conventional Commits (e.g., `feat: add standings endpoint`) with ≤72-character summaries and focused scope.
-- Before opening a PR, confirm all checks pass locally: `just ci` (lint + ty + test), `just ci-e2e` (if relevant), and `just security`.
-- Push the branch and create a PR via `gh pr create` with a clear title and description. Link related issues with `Closes #N`.
-- After CI passes on the PR, merge via `gh pr merge --squash` (or `--merge` for multi-commit PRs worth preserving).
-- Delete the branch after merge: `git branch -d <branch> && git push origin --delete <branch>`.
-- Update README or `docs/` when behavior or configuration shifts.
+```bash
+cd backend/src && ../../.venv/bin/python -m pytest utest/test_main.py::test_get_weekly_games -v
+```
 
-## Security & Configuration Tips
+- Filter tests by name pattern:
 
-- Store secrets via GitHub OIDC or environment variables; never commit `.env`. Terraform state stays in S3 + Dynamo.
-- Validate incoming payloads in backend and parser layers, and protect file writes under `backend/src/data/`.
-- Remove debug logging before review and justify any suppressed Bandit rules directly in PR discussions.
+```bash
+cd frontend/src && ../../.venv/bin/python -m pytest utest/ -k "offline or navigation" -v
+```
 
-## Deployment & Ops
+## E2E (Playwright / TypeScript) Commands
 
-- Dockerfiles per service build minimal images; `compose.yaml` orchestrates backend + frontend containers in dev.
-- Terraform under `terraform/` provisions AWS Lightsail and remote state; follow docs in `docs/` for IAM and deployment sequencing.
+- Install E2E deps (if needed): `cd e2e && bun install`.
+- E2E lint: `just lint-e2e`.
+- E2E format: `just fmt-e2e`.
+- E2E type check: `just ty-e2e`.
+- E2E CI tests: `just test-e2e` (runs `bun run test:ci`).
+- Run a single E2E spec:
+
+```bash
+cd e2e && bun run test -- tests/home.spec.ts
+```
+
+- Run a single E2E test title:
+
+```bash
+cd e2e && bun run test -- -g "navigation"
+```
+
+## Repository-Specific Coding Rules
+
+- Keep tests deterministic; do not rely on live ESPN/network in unit tests.
+- Prefer mocking `httpx.get` in backend tests and `requests.get` in frontend tests.
+- Preserve API query parameter naming in camelCase (`seasonType`) for external/API compatibility.
+- Preserve Python internal naming in snake_case.
+- Keep standings cache schema stable for backend consumers.
+- Do not remove stale-cache fallback behavior in backend fetch flows.
+
+## Python Style Guidelines
+
+- Formatter/linter authority: Ruff (configured in root `pyproject.toml`).
+- Line length target: 99 chars (Ruff default unless overridden by tool).
+- Imports:
+  - Group as stdlib, third-party, local.
+  - Prefer absolute imports; use relative imports in tests where already established.
+  - Avoid wildcard imports.
+- Naming:
+  - Modules/functions/variables: `snake_case`.
+  - Classes/Pydantic models: `PascalCase`.
+  - Constants/env defaults: `UPPER_SNAKE_CASE`.
+- Types:
+  - Use modern annotations (`str | None`, `list[dict]`) on new code.
+  - Add explicit return types for non-trivial functions.
+  - Keep models typed with Pydantic `BaseModel` where payload contracts matter.
+- Data handling:
+  - Parse external payloads defensively (`.get`, type checks, fallback defaults).
+  - Keep template-facing data JSON-serializable.
+  - Normalize external API payloads before returning to clients/templates.
+- Error handling:
+  - Catch narrow exceptions where practical (`ValueError`, `TypeError`, request exceptions).
+  - Use graceful degradation and fallback responses over crashes.
+  - In FastAPI routes, use `HTTPException` for client-visible errors.
+  - In frontend route handlers, prefer rendering fallback template over raising.
+- Logging:
+  - Use `logging` (not `print`) for runtime diagnostics.
+  - Keep logs concise and actionable; avoid noisy debug logs in committed code.
+
+## TypeScript E2E Style Guidelines
+
+- ESLint + Prettier are the style sources for `e2e/tests/**/*.ts`.
+- Prettier defaults: single quotes, semicolons, trailing commas, print width 80.
+- Prefer Playwright role/text locators (`getByRole`, `getByText`) and web-first assertions.
+- Avoid hard waits; use Playwright auto-waiting assertions.
+- Keep tests feature-focused in `*.spec.ts`; place API specs under `e2e/tests/api/`.
+
+## Change Management Expectations
+
+- Keep changes scoped; avoid unrelated refactors.
+- Update tests in the same PR as behavior changes.
+- Run targeted tests + lint before handoff; use `just ci` for broad Python changes.
+- Never commit secrets or `.env` files.

--- a/e2e/tests/home.spec.ts
+++ b/e2e/tests/home.spec.ts
@@ -137,7 +137,7 @@ test.describe('Light Score - Home Page', () => {
   test('is responsive and accessible', async ({ page }) => {
     await test.step('verify accessibility structure', async () => {
       // Check for proper heading hierarchy
-      const h1Count = await page.locator('h1').count();
+      const _h1Count = await page.locator('h1').count();
       const h2Count = await page.locator('h2').count();
 
       expect(h2Count).toBeGreaterThanOrEqual(3); // Live, Games, Standings

--- a/e2e/tests/home.spec.ts
+++ b/e2e/tests/home.spec.ts
@@ -7,8 +7,7 @@ test.describe('Light Score - Home Page', () => {
 
   test.beforeEach(async ({ page }) => {
     // Navigate to home page before each test
-    // Force seasonType=2 to ensure Standings are visible for these tests
-    await page.goto('/?seasonType=2', { waitUntil: 'networkidle' });
+    await page.goto('/', { waitUntil: 'networkidle' });
   });
 
   test.describe('@smoke', () => {
@@ -138,7 +137,7 @@ test.describe('Light Score - Home Page', () => {
   test('is responsive and accessible', async ({ page }) => {
     await test.step('verify accessibility structure', async () => {
       // Check for proper heading hierarchy
-      const _h1Count = await page.locator('h1').count();
+      const h1Count = await page.locator('h1').count();
       const h2Count = await page.locator('h2').count();
 
       expect(h2Count).toBeGreaterThanOrEqual(3); // Live, Games, Standings

--- a/e2e/tests/home.spec.ts
+++ b/e2e/tests/home.spec.ts
@@ -7,7 +7,8 @@ test.describe('Light Score - Home Page', () => {
 
   test.beforeEach(async ({ page }) => {
     // Navigate to home page before each test
-    await page.goto('/', { waitUntil: 'networkidle' });
+    // Force regular season so Standings section is consistently rendered
+    await page.goto('/?seasonType=2', { waitUntil: 'networkidle' });
   });
 
   test.describe('@smoke', () => {

--- a/e2e/tests/site-navigation.spec.ts
+++ b/e2e/tests/site-navigation.spec.ts
@@ -23,7 +23,7 @@ test.describe('External NFL Site - Navigation and Health Checks', () => {
     page.on('console', msg => {
       try {
         consoleMessages.push(`${msg.type()}: ${msg.text()}`);
-      } catch (e) {
+      } catch (_e) {
         // Silently ignore console logging errors
       }
     });
@@ -65,7 +65,7 @@ test.describe('External NFL Site - Navigation and Health Checks', () => {
               await page.waitForTimeout(500);
               break;
             }
-          } catch (e) {
+          } catch (_e) {
             // Continue to next button type if this one fails
           }
         }

--- a/e2e/tests/site-navigation.spec.ts
+++ b/e2e/tests/site-navigation.spec.ts
@@ -23,7 +23,7 @@ test.describe('External NFL Site - Navigation and Health Checks', () => {
     page.on('console', msg => {
       try {
         consoleMessages.push(`${msg.type()}: ${msg.text()}`);
-      } catch (_e) {
+      } catch (e) {
         // Silently ignore console logging errors
       }
     });
@@ -65,7 +65,7 @@ test.describe('External NFL Site - Navigation and Health Checks', () => {
               await page.waitForTimeout(500);
               break;
             }
-          } catch (_e) {
+          } catch (e) {
             // Continue to next button type if this one fails
           }
         }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,10 +15,10 @@ backend = [
     "pydantic>=2.11.0",
 ]
 frontend = [
-    "flask>=3.1.1",
-    "werkzeug>=3.1.4",
+    "flask>=3.1.3",
+    "werkzeug>=3.1.6",
     "gunicorn>=23.0.0",
-    "requests>=2.32.4",
+    "requests>=2.33.0",
     "urllib3>=2.6.0",
 ]
 functions = [
@@ -43,6 +43,7 @@ select = ["E4", "E7", "E9", "F", "B", "Q"]
 [dependency-groups]
 dev = [
     "pytest>=8.3.0",
+    "pygments>=2.20.0",
     "ruff>=0.6.4",
     "ty>=0.0.1a18",
     "types-requests>=2.32.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -217,7 +217,7 @@ wheels = [
 
 [[package]]
 name = "flask"
-version = "3.1.2"
+version = "3.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "blinker" },
@@ -227,9 +227,9 @@ dependencies = [
     { name = "markupsafe" },
     { name = "werkzeug" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dc/6d/cfe3c0fcc5e477df242b98bfe186a4c34357b4847e87ecaef04507332dab/flask-3.1.2.tar.gz", hash = "sha256:bf656c15c80190ed628ad08cdfd3aaa35beb087855e2f494910aa3774cc4fd87", size = 720160, upload-time = "2025-08-19T21:03:21.205Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/00/35d85dcce6c57fdc871f3867d465d780f302a175ea360f62533f12b27e2b/flask-3.1.3.tar.gz", hash = "sha256:0ef0e52b8a9cd932855379197dd8f94047b359ca0a78695144304cb45f87c9eb", size = 759004, upload-time = "2026-02-19T05:00:57.678Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/f9/7f9263c5695f4bd0023734af91bedb2ff8209e8de6ead162f35d8dc762fd/flask-3.1.2-py3-none-any.whl", hash = "sha256:ca1d8112ec8a6158cc29ea4858963350011b5c846a414cdb7a954aa9e967d03c", size = 103308, upload-time = "2025-08-19T21:03:19.499Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/9c/34f6962f9b9e9c71f6e5ed806e0d0ff03c9d1b0b2340088a0cf4bce09b18/flask-3.1.3-py3-none-any.whl", hash = "sha256:f4bcbefc124291925f1a26446da31a5178f9483862233b23c0c96a20701f670c", size = 103424, upload-time = "2026-02-19T05:00:56.027Z" },
 ]
 
 [[package]]
@@ -400,6 +400,7 @@ security = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pygments" },
     { name = "pytest" },
     { name = "ruff" },
     { name = "ty" },
@@ -411,7 +412,7 @@ requires-dist = [
     { name = "bandit", extras = ["toml"], marker = "extra == 'security'", specifier = "==1.8.0" },
     { name = "beautifulsoup4", marker = "extra == 'functions'", specifier = "==4.12.3" },
     { name = "fastapi", marker = "extra == 'backend'", specifier = ">=0.124.0" },
-    { name = "flask", marker = "extra == 'frontend'", specifier = ">=3.1.1" },
+    { name = "flask", marker = "extra == 'frontend'", specifier = ">=3.1.3" },
     { name = "gunicorn", marker = "extra == 'frontend'", specifier = ">=23.0.0" },
     { name = "httpx", marker = "extra == 'backend'", specifier = ">=0.28.1" },
     { name = "httpx", marker = "extra == 'functions'", specifier = "==0.28.1" },
@@ -419,16 +420,17 @@ requires-dist = [
     { name = "pip-audit", marker = "extra == 'security'", specifier = "==2.7.0" },
     { name = "pydantic", marker = "extra == 'backend'", specifier = ">=2.11.0" },
     { name = "pydantic", marker = "extra == 'functions'", specifier = "==2.11.7" },
-    { name = "requests", marker = "extra == 'frontend'", specifier = ">=2.32.4" },
+    { name = "requests", marker = "extra == 'frontend'", specifier = ">=2.33.0" },
     { name = "starlette", marker = "extra == 'backend'", specifier = ">=0.49.1" },
     { name = "urllib3", marker = "extra == 'frontend'", specifier = ">=2.6.0" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'backend'", specifier = ">=0.35.0" },
-    { name = "werkzeug", marker = "extra == 'frontend'", specifier = ">=3.1.4" },
+    { name = "werkzeug", marker = "extra == 'frontend'", specifier = ">=3.1.6" },
 ]
 provides-extras = ["backend", "frontend", "functions", "security"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pygments", specifier = ">=2.20.0" },
     { name = "pytest", specifier = ">=8.3.0" },
     { name = "ruff", specifier = ">=0.6.4" },
     { name = "ty", specifier = ">=0.0.1a18" },
@@ -706,11 +708,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]
@@ -785,7 +787,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.5"
+version = "2.33.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -793,9 +795,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
 ]
 
 [[package]]
@@ -1113,12 +1115,12 @@ wheels = [
 
 [[package]]
 name = "werkzeug"
-version = "3.1.5"
+version = "3.1.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5a/70/1469ef1d3542ae7c2c7b72bd5e3a4e6ee69d7978fa8a3af05a38eca5becf/werkzeug-3.1.5.tar.gz", hash = "sha256:6a548b0e88955dd07ccb25539d7d0cc97417ee9e179677d22c7041c8f078ce67", size = 864754, upload-time = "2026-01-08T17:49:23.247Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/43/76ded108b296a49f52de6bac5192ca1c4be84e886f9b5c9ba8427d9694fd/werkzeug-3.1.7.tar.gz", hash = "sha256:fb8c01fe6ab13b9b7cdb46892b99b1d66754e1d7ab8e542e865ec13f526b5351", size = 875700, upload-time = "2026-03-24T01:08:07.687Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/e4/8d97cca767bcc1be76d16fb76951608305561c6e056811587f36cb1316a8/werkzeug-3.1.5-py3-none-any.whl", hash = "sha256:5111e36e91086ece91f93268bb39b4a35c1e6f1feac762c9c822ded0a4e322dc", size = 225025, upload-time = "2026-01-08T17:49:21.859Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/b2/0bba9bbb4596d2d2f285a16c2ab04118f6b957d8441566e1abb892e6a6b2/werkzeug-3.1.7-py3-none-any.whl", hash = "sha256:4b314d81163a3e1a169b6a0be2a000a0e204e8873c5de6586f453c55688d422f", size = 226295, upload-time = "2026-03-24T01:08:06.133Z" },
 ]


### PR DESCRIPTION
## Summary
- refresh `AGENTS.md` with current build/lint/test workflows, including single-test commands and repo-specific coding guidance for agents
- bump vulnerable dependencies (`flask`, `werkzeug`, `requests`, `pygments`) and regenerate `uv.lock` to clear `pip-audit` findings
- clean E2E test lint warnings by aligning intentionally unused variables with the ESLint underscore convention

## Validation
- `just sync`
- `just lint`
- `just test`
- `just security`
- `just lint-e2e`
- `just ty-e2e`
- `just --set docker docker mock-up`
- `just test-e2e` (suite executed; tests were skipped in this environment)