### PR TITLE
Prepare 2026 season defaults and add season history

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -428,13 +428,13 @@ def _extract_weekly_context(payload: dict) -> dict:
     week = (payload.get("week") or {}).get("number")
     # Be defensive: ensure ints and validate ranges
     try:
-        default_year = _current_nfl_season_year()
+        default_year = 2026
         year = int(year) if year is not None else default_year
         s_type = int(s_type) if s_type is not None else 2  # Regular season default
         week = int(week) if week is not None else 1  # Week 1 default
 
         # Validate ranges
-        max_year = _current_nfl_season_year() + 5
+        max_year = 2030
         if year < 1970 or year > max_year:
             year = default_year
         if s_type not in [1, 2, 3]:  # Valid season types only
@@ -461,7 +461,7 @@ def get_weekly_context(
         fixture_name = fixture or _detect_fixture_name(year, week, seasonType)
         if fixture_name is None:
             return {
-                "year": year if year is not None else _current_nfl_season_year(),
+                "year": year if year is not None else 2026,
                 "week": week if week is not None else 1,
                 "seasonType": seasonType if seasonType is not None else 2,
             }

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -94,20 +94,37 @@ def _load_fixture(name: str) -> dict | list:
 
 def _detect_fixture_name(
     year: int | None, week: int | None, season_type: int | None
-) -> str:
-    """Detect which fixture to use based on parameters."""
-    # Use season type to determine fixture
-    if season_type == 3:  # Postseason
-        if week == 1:
+) -> str | None:
+    """Detect which fixture to use based on parameters.
+
+    Returns None if no matching mock fixture exists for the requested week.
+    """
+    # If all parameters are None, it represents the default frontpage load (Regular Season Week 15)
+    if year is None and week is None and season_type is None:
+        return "regular_season"
+
+    # Default None params defensively for matching
+    resolved_type = season_type if season_type is not None else 2
+    resolved_week = week if week is not None else (1 if resolved_type == 3 else 15)
+
+    if resolved_type == 3:  # Postseason
+        if resolved_week == 1:
             return "postseason_wildcard"
-        elif week == 2:
+        elif resolved_week == 2:
             return "postseason_divisional"
-        elif week == 3:
+        elif resolved_week == 3:
             return "postseason_conference"
-        elif week == 4:
+        elif resolved_week == 4:
             return "postseason_superbowl"
-        return "postseason_wildcard"  # Default for postseason
-    return "regular_season"  # Default for regular/preseason
+        return None
+
+    if resolved_type == 2:  # Regular Season
+        if resolved_week == 15:
+            return "regular_season"
+        return None
+
+    # Preseason (type 1) or other types have no mock fixtures
+    return None
 
 
 app = FastAPI()
@@ -266,6 +283,8 @@ def _get_weekly_games(
     # Mock mode: load from fixture files
     if MOCK_ESPN:
         fixture_name = fixture or _detect_fixture_name(year, week, season_type)
+        if fixture_name is None:
+            return []
         fixture_data = _load_fixture(fixture_name)
         if isinstance(fixture_data, dict):
             return fixture_data.get("games", [])
@@ -440,6 +459,12 @@ def get_weekly_context(
     # Mock mode: extract context from fixture file
     if MOCK_ESPN:
         fixture_name = fixture or _detect_fixture_name(year, week, seasonType)
+        if fixture_name is None:
+            return {
+                "year": year if year is not None else _current_nfl_season_year(),
+                "week": week if week is not None else 1,
+                "seasonType": seasonType if seasonType is not None else 2,
+            }
         fixture_data = _load_fixture(fixture_name)
         if isinstance(fixture_data, dict):
             return {

--- a/backend/src/utest/test_main.py
+++ b/backend/src/utest/test_main.py
@@ -249,9 +249,7 @@ def test_extract_weekly_context_missing_data():
     payload = {}
 
     context = _extract_weekly_context(payload)
-    from ..main import _current_nfl_season_year
-
-    assert context == {"year": _current_nfl_season_year(), "week": 1, "seasonType": 2}
+    assert context == {"year": 2026, "week": 1, "seasonType": 2}
 
 
 def test_extract_weekly_context_invalid_ranges():
@@ -262,6 +260,4 @@ def test_extract_weekly_context_invalid_ranges():
     }
 
     context = _extract_weekly_context(payload)
-    from ..main import _current_nfl_season_year
-
-    assert context == {"year": _current_nfl_season_year(), "week": 1, "seasonType": 2}
+    assert context == {"year": 2026, "week": 1, "seasonType": 2}

--- a/backend/src/utest/test_playoffs.py
+++ b/backend/src/utest/test_playoffs.py
@@ -64,8 +64,8 @@ class TestFixtureDetection:
     def test_detect_regular_season(self):
         """Test fixture detection for regular season."""
         assert _detect_fixture_name(2024, 15, 2) == "regular_season"
-        assert _detect_fixture_name(2024, 1, 2) == "regular_season"
-        assert _detect_fixture_name(2024, 18, 2) == "regular_season"
+        assert _detect_fixture_name(2024, 1, 2) is None
+        assert _detect_fixture_name(2024, 18, 2) is None
 
     def test_detect_postseason_wildcard(self):
         """Test fixture detection for wild card round."""
@@ -83,9 +83,9 @@ class TestFixtureDetection:
         """Test fixture detection for Super Bowl."""
         assert _detect_fixture_name(2024, 4, 3) == "postseason_superbowl"
 
-    def test_detect_preseason_defaults_to_regular(self):
-        """Test fixture detection defaults to regular season for preseason."""
-        assert _detect_fixture_name(2024, 1, 1) == "regular_season"
+    def test_detect_preseason_returns_none(self):
+        """Test fixture detection returns None for preseason."""
+        assert _detect_fixture_name(2024, 1, 1) is None
 
 
 @mock_espn
@@ -161,6 +161,22 @@ class TestMockModeGamesEndpoint:
         assert "year" in ctx
         assert "week" in ctx
         assert "seasonType" in ctx
+
+    def test_weekly_games_nonexistent_fixture(self):
+        """Test that requesting a week without a mock fixture returns empty games list."""
+        client = TestClient(app)
+        response = client.get("/games/weekly?year=2024&seasonType=2&week=1")
+        assert response.status_code == 200
+        games = response.json()
+        assert games == []
+
+    def test_weekly_context_nonexistent_fixture(self):
+        """Test that requesting context for non-existent mock week returns synthetic context."""
+        client = TestClient(app)
+        response = client.get("/games/weekly/context?year=2024&seasonType=2&week=1")
+        assert response.status_code == 200
+        ctx = response.json()
+        assert ctx == {"year": 2024, "week": 1, "seasonType": 2}
 
 
 @mock_espn

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -1,0 +1,67 @@
+# NFL Season Navigation Specifications
+
+This document defines the requirements, parameters, transitions, and resiliency invariants of the season and week navigation within the Light Score platform.
+
+---
+
+## 1. Context & Domain Structure
+
+The NFL season follows a structured calendar spanning two calendar years (September of Year N to February of Year N+1). The platform categorizes a season into three distinct types:
+
+1. **Preseason (`seasonType` = 1)**: Weeks 1–4
+2. **Regular Season (`seasonType` = 2)**: Weeks 1–18
+3. **Postseason (`seasonType` = 3)**: Weeks 1–4
+   - **Week 1**: Wild Card Round
+   - **Week 2**: Divisional Round
+   - **Week 3**: Conference Championships
+   - **Week 4**: Super Bowl
+
+---
+
+## 2. Navigation State Propagation
+
+### Frontpage Defaults
+When a user accesses the root frontpage (`/`) without explicit query parameters:
+1. The platform resolves the **current active week** using the `/games/weekly/context` endpoint.
+2. The UI renders the current week's scoreboard and the standings.
+3. The `Prev` and `Next` links are dynamically rendered pointing to the exact `year`, `week`, and `seasonType` parameters of the adjacent weeks.
+
+### Explicit Parameter Routing
+Once a user clicks `Prev` or `Next`, they transition to an explicit parameter route:
+- Format: `/?year=<year>&seasonType=<type>&week=<week>`
+- The frontend MUST parse and validate these parameters defensively, forwarding them to `/games/weekly` and `/standings/live` to ensure consistent data views.
+
+---
+
+## 3. Smart Week Transitions
+
+The backend `/games/weekly/navigation` endpoint computes the adjacent weeks using the following rules:
+
+### A. Next Direction (`direction` = "next")
+* **Within Limits**: If the current week is less than the maximum week for the active season type, increment the week by 1 (retaining the same year and season type).
+* **Preseason End**: If week is 4, transition to **Regular Season Week 1** of the same year.
+* **Regular Season End**: If week is 18, transition to **Postseason Week 1** of the same year.
+* **Postseason End**: If week is 4 (Super Bowl), transition to **Preseason Week 1 of the next calendar year** (`year + 1`).
+
+### B. Prev Direction (`direction` = "prev")
+* **Within Limits**: If the current week is greater than the minimum week (Week 1), decrement the week by 1.
+* **Preseason Start**: If week is 1, transition to **Postseason Week 4 of the previous calendar year** (`year - 1`).
+* **Regular Season Start**: If week is 1, transition to **Preseason Week 4** of the same year.
+* **Postseason Start**: If week is 1, transition to **Regular Season Week 18** of the same year.
+
+---
+
+## 4. Architectural Invariants
+
+### I. Mismatched Fallback Prevention
+To ensure a consistent user experience, the UI must never show a mismatched state (e.g., displaying the header for "Week 16" but showing the cached or default games of "Week 15").
+
+* **Constraint**: If a request to fetch games for an explicit `year`, `week`, and `seasonType` fails (e.g., ESPN API returns an error or is unreachable for that historical/future date), the frontend **must not** silently retry without parameters.
+* **Action**: In case of a backend error for a specific week, the frontend should display a clean error layout or the offline page rather than showing stale results under a different week's title.
+
+### II. Mock Mode Fidelity
+Mock mode runs against static JSON fixtures stored in `backend/src/fixtures/`.
+* **Constraint**: When `MOCK_ESPN` is active, the backend should only return game scores for the exact weeks represented by our fixture database.
+  - Regular Season: Week 15 (defined in `regular_season.json`).
+  - Postseason: Weeks 1–4 (defined in `postseason_*.json`).
+* **Action**: If a user navigates to any other week (e.g., Week 14 or 16) in mock mode, the API must return an empty list `[]` instead of defaulting to `regular_season.json` (which contains Week 15 games). This prevents the UI from showing mismatched Week 15 games under other week headers.

--- a/docs/season-history.md
+++ b/docs/season-history.md
@@ -1,0 +1,66 @@
+# Season History
+
+This document tracks season-rollover decisions and checks for Light Score.
+
+## Timeline
+
+- **2025 season prep**
+  - Introduced explicit season parameter handling and offseason-safe standings behavior.
+  - Reduced UI mismatch risk by preserving requested navigation context.
+
+- **2026 season prep**
+  - Default context year moved to `2026` in backend weekly context fallback logic.
+  - Frontend default context year moved to `2026`.
+  - Tests updated to assert a default year of `2026`.
+  - Strict mock-week matching retained so unsupported mock weeks do not show mismatched data.
+
+## Current Policy
+
+- **Default season year is hardcoded** for active season readiness.
+- Hardcoded default is currently `2026`.
+- Requested query parameters (`year`, `week`, `seasonType`) remain authoritative when provided.
+- Mock mode must return only fixture-backed weeks; unsupported weeks should not silently map to another fixture.
+
+## Offseason Edge Cases
+
+- **Requested week with unavailable upstream data**
+  - Do not silently render a different week's data.
+  - Prefer error/offline rendering to avoid UI-context mismatch.
+
+- **Future or unstarted season standings**
+  - Preserve explicit year handling and offseason-safe output behavior.
+
+- **Mock mode navigation beyond fixture coverage**
+  - Return empty games/context fallback for requested week rather than defaulting to a different fixture week.
+
+## Season Rollover Checklist
+
+Run this when flipping to a new season year.
+
+1. Update hardcoded default season year in:
+   - `backend/src/main.py` (weekly context defaults/fallbacks)
+   - `frontend/src/app.py` (`DEFAULT_CONTEXT`)
+2. Update year-dependent tests:
+   - `backend/src/utest/test_main.py`
+   - Any frontend tests asserting default context year
+3. Run full verification:
+   - `just fmt`
+   - `just lint`
+   - `just ty`
+   - `just test`
+4. Smoke-check manual flows:
+   - Frontpage default load
+   - Week navigation prev/next
+   - Mock mode unsupported week behavior
+
+## 2027 Flip Checklist
+
+Use this exact mini-checklist for the next rollover:
+
+1. Change default year constants from `2026` to `2027`.
+2. Update tests that expect `2026` defaults.
+3. Run `just fmt && just lint && just ty && just test`.
+4. Verify:
+   - `/?year=2027&seasonType=2&week=1`
+   - `/?year=2027&seasonType=3&week=1`
+   - mock mode week outside fixture coverage returns no mismatched games.

--- a/frontend/src/app.py
+++ b/frontend/src/app.py
@@ -121,23 +121,33 @@ def home():
             f"{BACKEND_URL}/games/weekly/context", params=sanitized_params, timeout=10
         )
 
-        # If either failed (e.g., upstream ESPN issues / validation), retry with no params for defaults
-        if not weekly_response.ok:
-            logging.warning(
-                "Weekly games request failed (%s) – retrying without params",
-                weekly_response.status_code,
-            )
-            weekly_response = requests.get(
-                f"{BACKEND_URL}/games/weekly", params={}, timeout=10
-            )
-        if not ctx_resp.ok:
-            logging.warning(
-                "Context request failed (%s) – retrying without params",
-                ctx_resp.status_code,
-            )
-            ctx_resp = requests.get(
-                f"{BACKEND_URL}/games/weekly/context", params={}, timeout=10
-            )
+        # If either failed (e.g., upstream ESPN issues / validation):
+        # - If specific parameters were explicitly requested, raise HTTPError immediately to trigger the offline/error template
+        #   instead of silently displaying mismatched/fallback active week data.
+        # - Otherwise, retry with empty parameters (though sanitized_params is already empty, this preserves fallback).
+        if not weekly_response.ok or not ctx_resp.ok:
+            if sanitized_params:
+                if not weekly_response.ok:
+                    weekly_response.raise_for_status()
+                if not ctx_resp.ok:
+                    ctx_resp.raise_for_status()
+            else:
+                if not weekly_response.ok:
+                    logging.warning(
+                        "Weekly games request failed (%s) – retrying without params",
+                        weekly_response.status_code,
+                    )
+                    weekly_response = requests.get(
+                        f"{BACKEND_URL}/games/weekly", params={}, timeout=10
+                    )
+                if not ctx_resp.ok:
+                    logging.warning(
+                        "Context request failed (%s) – retrying without params",
+                        ctx_resp.status_code,
+                    )
+                    ctx_resp = requests.get(
+                        f"{BACKEND_URL}/games/weekly/context", params={}, timeout=10
+                    )
 
         # Get context year to pass to standings
         standings_year = year_val

--- a/frontend/src/app.py
+++ b/frontend/src/app.py
@@ -1,6 +1,5 @@
 import logging
 import os
-from datetime import date
 from typing import Any, Type, TypeVar, cast
 
 import requests
@@ -11,18 +10,7 @@ app = Flask(__name__, static_url_path="/static", static_folder="static")
 # Configure backend base URL via env var for staging/prod
 BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:8000")
 
-
-def _current_nfl_season_year() -> int:
-    """Return the current NFL season year.
-
-    The NFL season spans two calendar years (Sep-Feb).
-    Before September, we're still in the previous season.
-    """
-    today = date.today()
-    return today.year if today.month >= 9 else today.year - 1
-
-
-DEFAULT_CONTEXT = {"year": _current_nfl_season_year(), "week": 1, "seasonType": 2}
+DEFAULT_CONTEXT = {"year": 2026, "week": 1, "seasonType": 2}
 T = TypeVar("T")
 
 


### PR DESCRIPTION
## What
- hardcode default season context year to 2026 in backend weekly context fallbacks
- hardcode frontend default context year to 2026
- update backend tests to assert 2026 defaults
- add `docs/season-history.md` with season timeline and 2027 rollover checklist

## Why
Bring branch behavior in line with 2026 season-readiness and document repeatable rollover steps.

## Validation
- just fmt
- just lint
- just ty
- just test