### PR TITLE
docs: add current requirements, state, and decision log

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ just security    # bandit + pip-audit
 
 CI → Security → Deploy (Lightsail). Terraform remote state (S3 + Dynamo, prefix scoped). Images built & pushed with `lightsailctl`; `BACKEND_URL` set to internal DNS. See `docs/aws-iam-permissions.md`.
 
+## Canonical Product Docs
+
+- Current requirements: `docs/current-requirements.md`
+- Current implementation state: `docs/current-state.md`
+- Decision log: `docs/decision-log.md`
+
 ## Secrets
 
 GitHub: `AWS_ROLE_TO_ASSUME` (OIDC). No static AWS keys.

--- a/docs/current-requirements.md
+++ b/docs/current-requirements.md
@@ -1,0 +1,84 @@
+# Current Requirements
+
+This document defines the current, test-backed requirements for Light Score.
+It is intentionally scoped to what the app does today.
+
+## Scope
+
+- Product scope: NFL weekly scoreboard and standings UI, rendered by Flask.
+- Delivery scope: backend data fetch + frontend rendering + graceful fallback behavior.
+- This is a baseline for change control, not a roadmap.
+
+## Functional Requirements
+
+### FR-001 Main Page Rendering
+
+- The frontend serves a main page at `/`.
+- The page renders Light Score branding and core sections for games data.
+- In regular season contexts, the page shows `Live`, `Games`, and `Standings` panels.
+
+### FR-002 Query Parameter Contract
+
+- The frontend accepts `year`, `week`, and `seasonType` query parameters.
+- Input values are sanitized to valid integer ranges before forwarding to backend endpoints.
+- Invalid query values are ignored rather than causing an app error.
+
+### FR-003 Week Navigation
+
+- Week navigation is link-based (`Prev` and `Next`) on the main page.
+- Navigation parameters are sourced from backend navigation data when available.
+- If navigation endpoint calls fail, the frontend computes safe local fallback values.
+
+### FR-004 Games Rendering States
+
+- Weekly games are rendered from backend payloads and partitioned into:
+  - `live`
+  - `final`
+  - `upcoming`
+- Live games appear in the `Live` panel.
+- Final and upcoming games appear in the `Games` panel.
+
+### FR-005 Standings Rendering
+
+- Standings are loaded from live standings first and cache fallback second.
+- Standings are grouped by division when division data exists.
+- Team ordering within a division is sorted by wins descending, losses ascending, then team name.
+
+### FR-006 Postseason Bracket Behavior
+
+- In postseason context (`seasonType=3`), frontend attempts to fetch bracket data.
+- If bracket data is available and valid, a `Playoff Bracket` panel is rendered.
+- If bracket data is unavailable, the app degrades safely and still renders the page.
+
+## Resilience Requirements
+
+### RR-001 Offline UI Fallback
+
+- If backend requests fail at network level, frontend renders `home_no_api.html`.
+- Offline page remains user-visible and branded instead of returning an application crash.
+
+### RR-002 Defensive Payload Parsing
+
+- Backend responses are parsed defensively.
+- Unexpected payload types or error/detail payloads fall back to safe defaults.
+- Rendering continues with partial/empty data where necessary.
+
+## UI and Accessibility Baseline
+
+- UI uses teletext-inspired styling and a monospaced presentation.
+- Layout is responsive across desktop/tablet/mobile viewports.
+- Navigation and key data regions retain basic accessibility semantics (headings, labels, visible links).
+
+## Non-Goals (Current Baseline)
+
+- No strict viewport-locked 4:3 rendering engine.
+- No zero-scroll hard input interception model.
+- No global 3-digit teletext page router (`P100` style keyboard routing).
+- No mandatory fast-text color hotkey engine (`R/G/Y/B`) as a current guarantee.
+
+## Traceability
+
+- Frontend behavior: `frontend/src/app.py`, `frontend/src/templates/home.html`, `frontend/src/templates/home_no_api.html`.
+- Frontend unit tests: `frontend/src/utest/test_app.py`.
+- E2E behavior checks: `e2e/tests/home.spec.ts`, `e2e/tests/application.spec.ts`, `e2e/tests/playoff-bracket.spec.ts`, `e2e/tests/error-handling.spec.ts`.
+- Backend dependency surface: `backend/src/main.py` (`/games/weekly`, `/games/weekly/context`, `/games/weekly/navigation`, `/standings`, `/standings/live`, `/playoffs/bracket`).

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -1,0 +1,89 @@
+# Current State
+
+This document captures the implementation state of Light Score as of today.
+It describes what exists in code and tests, without proposing redesign work.
+
+## Architecture Snapshot
+
+- Monorepo with:
+  - `backend/` FastAPI API for games, standings, navigation, playoff data.
+  - `frontend/` Flask + Jinja web UI.
+  - `functions/` data parsing/caching support utilities.
+  - `e2e/` Playwright TypeScript tests.
+- Frontend and backend run independently and communicate over HTTP.
+
+## Runtime Flow
+
+1. Browser requests `/` from Flask frontend.
+2. Frontend sanitizes `year`, `week`, `seasonType` query params.
+3. Frontend fetches:
+   - `/games/weekly`
+   - `/games/weekly/context`
+   - `/standings/live` (fallback to `/standings`)
+4. Frontend fetches `/games/weekly/navigation` for prev/next links.
+5. If `seasonType=3`, frontend optionally fetches `/playoffs/bracket`.
+6. Frontend renders `home.html` or `home_no_api.html` on network failure.
+
+## Frontend State
+
+- Entry point: `frontend/src/app.py`.
+- Main route: `/`.
+- Templates currently in use:
+  - `frontend/src/templates/home.html`
+  - `frontend/src/templates/home_no_api.html`
+- Static styling: `frontend/src/static/teletext.css`.
+
+Current UI behavior:
+
+- Header shows season context and week navigation links.
+- `Live` panel shows in-progress games or empty-state message.
+- `Games` panel shows final/upcoming games with status-specific rendering.
+- Regular season path renders standings grouped by division.
+- Postseason path renders playoff bracket when bracket data is available.
+
+## Backend Dependency Surface Used by Frontend
+
+- `/games/weekly`
+- `/games/weekly/context`
+- `/games/weekly/navigation`
+- `/standings/live`
+- `/standings`
+- `/playoffs/bracket`
+
+## Data/State Handling Details
+
+- Query values are parsed defensively and bounded to accepted ranges.
+- Weekly games are filtered to valid records before rendering.
+- Games are split into `history`, `live`, and `upcoming` arrays.
+- Standings are grouped by division and sorted by record.
+- Navigation has both endpoint-driven and local fallback behavior.
+- Postseason bracket is conditional and non-fatal if unavailable.
+
+## Error and Degradation Behavior
+
+- Network-level request failures produce `home_no_api.html`.
+- Malformed JSON or incompatible payloads resolve to safe defaults.
+- Non-OK upstream responses trigger retries/fallback paths where implemented.
+
+## Test Coverage Signals
+
+- Frontend unit tests verify:
+  - main route rendering
+  - query/nav behavior
+  - offline fallback page
+  - postseason bracket panel path
+- E2E tests verify:
+  - core page structure and branding
+  - week navigation links and interactions
+  - standings and game state display behaviors
+  - postseason bracket UI structure
+  - basic responsiveness/accessibility expectations
+
+## Known Documentation Drift Resolved in This Pass
+
+- Frontend documentation had references to `/playoffs` and `playoffs.html` that do not
+  match current frontend route/template implementation.
+- Canonical behavior is now tracked in:
+  - `docs/current-requirements.md`
+  - `docs/current-state.md`
+  - `docs/decision-log.md`

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -1,0 +1,57 @@
+# Decision Log
+
+This log records lightweight architecture/product decisions for the current app.
+
+## DEC-001
+
+- Date: 2026-05-21
+- Status: accepted
+- Context: The product prioritizes delivery speed and stable backend-rendered pages.
+- Decision: Use Flask server-rendered templates for the primary UI surface.
+- Consequences: Simpler deploy/debug flow; less client-side app complexity.
+- Revisit Trigger: Need for richer client-side state/navigation beyond current patterns.
+
+## DEC-002
+
+- Date: 2026-05-21
+- Status: accepted
+- Context: Current week navigation requirements are straightforward and URL-driven.
+- Decision: Keep week navigation as visible `Prev`/`Next` links.
+- Consequences: Predictable behavior and testability; no global keyboard router required.
+- Revisit Trigger: Formal requirement for keyboard-first teletext routing.
+
+## DEC-003
+
+- Date: 2026-05-21
+- Status: accepted
+- Context: Upstream/backend availability can fail and should not blank the UI.
+- Decision: Render an explicit offline fallback page on network-level backend failures.
+- Consequences: Better user resilience; service degradation is visible but controlled.
+- Revisit Trigger: Adoption of alternative offline strategy (cached client state, etc.).
+
+## DEC-004
+
+- Date: 2026-05-21
+- Status: accepted
+- Context: Postseason data availability is conditional and should not break main flows.
+- Decision: Render playoff bracket conditionally inside `/` for `seasonType=3`.
+- Consequences: One primary entry route; bracket can gracefully disappear when unavailable.
+- Revisit Trigger: Need for dedicated postseason route or view model separation.
+
+## DEC-005
+
+- Date: 2026-05-21
+- Status: accepted
+- Context: External payload quality is variable and may include malformed/error shapes.
+- Decision: Parse backend responses defensively and default to safe empty structures.
+- Consequences: Fewer runtime crashes; some failures appear as empty states.
+- Revisit Trigger: Introduction of strict schema contracts with hard-fail handling.
+
+## DEC-006
+
+- Date: 2026-05-21
+- Status: accepted
+- Context: Existing API integrations and clients use camelCase query naming.
+- Decision: Preserve `seasonType` externally while using snake_case internally.
+- Consequences: Backward compatibility for API consumers; minor naming translation overhead.
+- Revisit Trigger: Versioned API migration that permits contract renaming.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -48,7 +48,6 @@ just mock-up
 | Route | Description |
 |-------|-------------|
 | `/` | Main scoreboard with games and standings |
-| `/playoffs` | Playoff picture/bracket view |
 | `/?seasonType=2` | Regular season view |
 | `/?seasonType=3` | Postseason view |
 | `/?week=N` | Specific week navigation |
@@ -57,9 +56,8 @@ just mock-up
 
 | Template | Purpose |
 |----------|---------|
-| `home.html` | Main scoreboard with games grid + standings |
+| `home.html` | Main scoreboard with games grid + standings or postseason bracket |
 | `home_no_api.html` | Fallback when backend is unavailable |
-| `playoffs.html` | Playoff bracket visualization |
 
 ## Testing
 


### PR DESCRIPTION
## What changed\n- added canonical current requirements doc\n- added current implementation state snapshot\n- added brief decision log (DEC-001..DEC-006)\n- linked canonical docs from root README\n- aligned frontend README with current routes/templates\n\n## Why\n- establish a clear, test-backed baseline for current behavior\n- separate current guarantees from future ideas\n- remove documentation drift around nonexistent frontend route/template\n\n## Notes\n- docs-only change\n- no runtime code paths changed