### PR TITLE
fix: reject mismatched offseason weekly fallback data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,4 @@ override.tf.json
 node_modules/
 playwright-report/
 test-results/
+.playwright-mcp/

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -269,6 +269,54 @@ def _extract_weekly_games_from_scoreboard(payload: dict) -> list[dict]:
     return result
 
 
+def _scoreboard_matches_requested_context(
+    payload: dict,
+    *,
+    year: int | None,
+    week: int | None,
+    season_type: int | None,
+) -> bool:
+    """Check whether ESPN scoreboard payload matches explicitly requested context."""
+    season = payload.get("season") or {}
+    payload_week_obj = payload.get("week") or {}
+    payload_year_value = season.get("year")
+    payload_type_value = season.get("type")
+    payload_week_value = payload_week_obj.get("number")
+
+    try:
+        payload_year = (
+            int(payload_year_value) if payload_year_value is not None else None
+        )
+    except (TypeError, ValueError):
+        payload_year = None
+
+    try:
+        payload_type = (
+            int(payload_type_value) if payload_type_value is not None else None
+        )
+    except (TypeError, ValueError):
+        payload_type = None
+
+    try:
+        payload_week = (
+            int(payload_week_value) if payload_week_value is not None else None
+        )
+    except (TypeError, ValueError):
+        payload_week = None
+
+    if year is not None and payload_year is not None and payload_year != year:
+        return False
+    if (
+        season_type is not None
+        and payload_type is not None
+        and payload_type != season_type
+    ):
+        return False
+    if week is not None and payload_week is not None and payload_week != week:
+        return False
+    return True
+
+
 ESPN_TIMEOUT_SECONDS = int(os.getenv("ESPN_TIMEOUT_SECONDS", "6"))
 
 
@@ -315,6 +363,13 @@ def _get_weekly_games(
         data = resp.json()
         if not isinstance(data, dict):
             raise TypeError(f"Expected dict response, got {type(data)}")
+        if not _scoreboard_matches_requested_context(
+            data,
+            year=year,
+            week=week,
+            season_type=season_type,
+        ):
+            return []
         games = _extract_weekly_games_from_scoreboard(data)
         if games:
             _games_cache[url] = (now, games)

--- a/backend/src/utest/test_live_standings.py
+++ b/backend/src/utest/test_live_standings.py
@@ -91,6 +91,45 @@ def test_weekly_games_from_scoreboard(mock_get):
 
 
 @patch("httpx.get")
+def test_weekly_games_returns_empty_on_requested_context_mismatch(mock_get):
+    payload = {
+        "season": {"year": 2025, "type": 1},
+        "week": {"number": 4},
+        "events": [
+            {
+                "competitions": [
+                    {
+                        "status": {"type": {"state": "post"}},
+                        "competitors": [
+                            {
+                                "homeAway": "away",
+                                "team": {"displayName": "Away Team"},
+                                "score": "10",
+                            },
+                            {
+                                "homeAway": "home",
+                                "team": {"displayName": "Home Team"},
+                                "score": "20",
+                            },
+                        ],
+                    }
+                ]
+            }
+        ],
+    }
+    mock_get.return_value.json.return_value = payload
+    mock_get.return_value.raise_for_status.return_value = None
+
+    from .. import main as backend_main
+
+    backend_main._games_cache.clear()
+
+    r = client.get("/games/weekly?year=2026&week=4&seasonType=1")
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+@patch("httpx.get")
 def test_teams_from_espn(mock_get):
     from .test_main import _teams_payload
 

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -54,6 +54,7 @@ Current UI behavior:
 
 - Query values are parsed defensively and bounded to accepted ranges.
 - Weekly games are filtered to valid records before rendering.
+- Weekly game fetch rejects upstream scoreboard payloads that do not match explicitly requested `year`/`week`/`seasonType`.
 - Games are split into `history`, `live`, and `upcoming` arrays.
 - Standings are grouped by division and sorted by record.
 - Navigation has both endpoint-driven and local fallback behavior.

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -55,3 +55,12 @@ This log records lightweight architecture/product decisions for the current app.
 - Decision: Preserve `seasonType` externally while using snake_case internally.
 - Consequences: Backward compatibility for API consumers; minor naming translation overhead.
 - Revisit Trigger: Versioned API migration that permits contract renaming.
+
+## DEC-007
+
+- Date: 2026-05-21
+- Status: accepted
+- Context: ESPN may return fallback scoreboard data from a different season/week when a requested period has no games yet.
+- Decision: Treat `/games/weekly` responses as valid only when returned season/year/week context matches explicit request params.
+- Consequences: Prevents stale historical scores from appearing for future navigation targets; empty game lists now represent unavailable periods.
+- Revisit Trigger: Upstream API guarantees strict context fidelity or product chooses explicit "nearest available week" behavior.


### PR DESCRIPTION
## What
- reject /games/weekly data when ESPN returns a different season/week/type than explicitly requested
- add backend regression test for 2026 preseason request receiving 2025 fallback finals
- document the decision in docs/decision-log.md (DEC-007) and current behavior in docs/current-state.md
- ignore Playwright MCP snapshots via .playwright-mcp/ in .gitignore

## Why
ESPN can return fallback scoreboard payloads from prior periods when the requested period has no games yet. That caused stale final scores to appear for 2026 preseason navigation targets.

## Validation
- just fmt
- just lint
- just ty
- just test
- just fmt-e2e
- just lint-e2e
- just ty-e2e