### PR TITLE
feat(frontend): teletext team badges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,7 @@ node_modules/
 playwright-report/
 test-results/
 .playwright-mcp/
+
+# Antigravity CLI
+.antigravitycli/
+

--- a/frontend/src/app.py
+++ b/frontend/src/app.py
@@ -66,62 +66,86 @@ def _fetch_playoff_bracket() -> dict[str, Any] | None:
     return None
 
 
-# Retro Teletext Team Logos Database
-TEAM_LOGOS = {
-    "cowboys": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#002244" rx="2"/><polygon points="8,2 10,6 15,6 11,9 13,14 8,11 3,14 5,9 1,6 6,6" fill="#ffffff"/></svg>',
-    "packers": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#183028" rx="2"/><circle cx="8" cy="8" r="6" fill="#ffb612"/><circle cx="8" cy="8" r="4.5" fill="#183028"/><rect x="8" y="7.5" width="4" height="2" fill="#ffb612"/><rect x="7" y="6" width="2.5" height="4" fill="#183028"/><rect x="8.5" y="6" width="2" height="2" fill="#ffb612"/></svg>',
-    "steelers": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#101820" rx="2"/><path d="M8,1 Q8,4 11,4 Q8,4 8,7 Q8,4 5,4 Q8,4 8,1" fill="#ffb612"/><path d="M12,7 Q12,10 15,10 Q12,10 12,13 Q12,10 9,10 Q12,10 12,7" fill="#c60c30"/><path d="M4,7 Q4,10 7,10 Q4,10 4,13 Q4,10 1,10 Q4,10 4,7" fill="#00539b"/></svg>',
-    "chiefs": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#e31837" rx="2"/><polygon points="8,1 15,6 11,14 5,14 1,6" fill="#ffffff"/><text x="8" y="11" font-size="7" font-family="monospace" font-weight="bold" text-anchor="middle" fill="#e31837">KC</text></svg>',
-    "raiders": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#101820" rx="2"/><polygon points="2,2 14,2 12,11 8,15 4,11" fill="#a5acaf"/><polygon points="3.5,3 12.5,3 10.5,10.5 8,13.5 5.5,10.5" fill="#101820"/><rect x="5" y="5" width="2" height="2" fill="#a5acaf"/><rect x="9" y="5" width="2" height="2" fill="#a5acaf"/><rect x="6" y="8" width="4" height="2.5" fill="#a5acaf"/></svg>',
-    "bills": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#00338d" rx="2"/><path d="M2,8 C4,5 12,5 14,8 C11,11 5,11 2,8" fill="#ffffff"/><rect x="2" y="7" width="12" height="2" fill="#c60c30" transform="rotate(15 8 8)"/></svg>',
-    "ravens": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#241773" rx="2"/><path d="M2,6 C4,4 12,4 14,7 C11,11 6,10 2,6" fill="#101820"/><circle cx="10" cy="6.5" r="1" fill="#ffb612"/><polygon points="2,6 6,7 2,8" fill="#ffb612"/></svg>',
-    "texans": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#03202f" rx="2"/><rect x="1" y="2" width="7" height="12" fill="#ffffff" rx="1"/><rect x="8" y="2" width="7" height="12" fill="#a71930" rx="1"/><polygon points="3,5 8,8 13,5 8,11" fill="#03202f"/><circle cx="8" cy="8" r="1.5" fill="#ffffff"/></svg>',
-    "broncos": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#0c2340" rx="2"/><path d="M2,12 C4,10 6,4 13,5 C10,6 11,9 14,9 C10,10 8,12 2,12" fill="#fc4c02"/><path d="M3,11 C5,10 7,6 12,7 C10,8 10,10 13,10 C10,11 8,11 3,11" fill="#ffffff"/><circle cx="10" cy="8" r="0.8" fill="#fc4c02"/></svg>',
-    "chargers": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#0080c6" rx="2"/><polygon points="12,2 5,9 8,9 3,14 11,6 8,6" fill="#ffc20e" stroke="#ffffff" stroke-width="0.75"/></svg>',
-    "patriots": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#002244" rx="2"/><path d="M2,5 Q8,2 14,6 Q10,10 2,5" fill="#a5acaf"/><path d="M2,5 Q8,2 14,6 Q10,8 2,9" fill="#c60c30"/><circle cx="5" cy="5" r="1" fill="#ffffff"/></svg>',
-    "bengals": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#fb4f14" rx="2"/><line x1="0" y1="3" x2="6" y2="5" stroke="#101820" stroke-width="1.5"/><line x1="16" y1="6" x2="10" y2="8" stroke="#101820" stroke-width="1.5"/><line x1="0" y1="9" x2="8" y2="10" stroke="#101820" stroke-width="1.5"/><line x1="16" y1="12" x2="8" y2="13" stroke="#101820" stroke-width="1.5"/></svg>',
-    "browns": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#eb3300" rx="2"/><rect x="6" width="4" height="16" fill="#ffffff"/><rect x="7" width="2" height="16" fill="#311d00"/></svg>',
-    "jaguars": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#006778" rx="2"/><circle cx="8" cy="8" r="5" fill="#d7a22a"/><rect x="7" y="5" width="2" height="2" fill="#000000"/><rect x="5" y="8" width="2" height="2" fill="#000000"/><rect x="9" y="8" width="2" height="2" fill="#000000"/><rect x="7" y="10" width="2" height="2" fill="#000000"/></svg>',
-    "colts": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#002c5f" rx="2"/><path d="M4,4 L4,9 C4,12 12,12 12,9 L12,4" fill="none" stroke="#ffffff" stroke-width="2.5"/><circle cx="5.5" cy="5" r="0.75" fill="#002c5f"/><circle cx="10.5" cy="5" r="0.75" fill="#002c5f"/><circle cx="5.5" cy="8" r="0.75" fill="#002c5f"/><circle cx="10.5" cy="8" r="0.75" fill="#002c5f"/><circle cx="8" cy="10.5" r="0.75" fill="#002c5f"/></svg>',
-    "titans": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#4b92db" rx="2"/><circle cx="8" cy="8" r="5" fill="#c60c30"/><polygon points="8,1 12,6 8,11 4,6" fill="#002244"/><rect x="7" y="4" width="2" height="6" fill="#ffffff"/><rect x="5" y="4" width="6" height="2" fill="#ffffff"/></svg>',
-    "jets": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#125740" rx="2"/><ellipse cx="8" cy="8" rx="7" ry="5" fill="none" stroke="#ffffff" stroke-width="1.5"/><text x="8" y="10.5" font-size="6.5" font-family="monospace" font-weight="bold" text-anchor="middle" fill="#ffffff">JETS</text></svg>',
-    "giants": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#0b2265" rx="2"/><text x="8" y="11" font-size="8.5" font-family="monospace" font-weight="bold" text-anchor="middle" fill="#ffffff">ny</text></svg>',
-    "eagles": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#004c54" rx="2"/><path d="M2,8 C4,4 12,4 14,5 C10,7 12,10 14,10 C10,11 6,12 2,8" fill="#a5acaf"/><path d="M3,8 C5,5 11,5 13,6 C9,8 11,10 13,10 C9,11 6,11 3,8" fill="#ffffff"/></svg>',
-    "lions": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#0076b6" rx="2"/><path d="M3,11 C5,8 6,4 13,5 C11,7 13,9 14,11 C10,12 6,12 3,11" fill="#b0b7bc"/><circle cx="5" cy="11" r="1.5" fill="#0076b6"/></svg>',
-    "vikings": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#4f2683" rx="2"/><path d="M3,5 C5,5 13,3 12,8 C11,11 6,13 4,9" fill="#ffffff"/><path d="M12,3 C10,5 11,8 12,8 C13,8 14,5 12,3" fill="#ffb612"/></svg>',
-    "bears": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#0b2265" rx="2"/><circle cx="8" cy="8" r="6" fill="#c83803"/><circle cx="8" cy="8" r="4" fill="#0b2265"/><rect x="7" y="5" width="6" height="6" fill="#0b2265"/><rect x="8.5" y="4" width="2.5" height="2" fill="#c83803"/><rect x="8.5" y="10" width="2.5" height="2" fill="#c83803"/></svg>',
-    "commanders": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#5a1414" rx="2"/><text x="8" y="12" font-size="12" font-family="monospace" font-weight="bold" text-anchor="middle" fill="#ffc20e">W</text></svg>',
-    "buccaneers": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#3a3a3a" rx="2"/><rect x="2" y="2" width="12" height="10" fill="#d50a0a"/><circle cx="8" cy="6" r="2" fill="#ffffff"/><line x1="5" y1="9" x2="11" y2="9" stroke="#ffffff" stroke-width="1.5"/></svg>',
-    "falcons": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#000000" rx="2"/><polygon points="2,4 14,4 12,8 8,12 4,8" fill="#a71930"/><polygon points="4,4 12,4 10,7 8,9 6,7" fill="#ffffff"/></svg>',
-    "panthers": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#101820" rx="2"/><path d="M2,6 C4,4 12,4 14,7 C10,9 12,12 14,12 C10,13 6,11 2,6" fill="#0085ca"/><circle cx="10" cy="7" r="1" fill="#ffffff"/></svg>',
-    "saints": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#101820" rx="2"/><path d="M8,2 C8,5 11,8 11,10 C11,12 9,13 8,13 C7,13 5,12 5,10 C5,8 8,5 8,2" fill="#d3bc8d"/><line x1="4" y1="10" x2="12" y2="10" stroke="#d3bc8d" stroke-width="2"/></svg>',
-    "49ers": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#aa0000" rx="2"/><ellipse cx="8" cy="8" rx="7" ry="5" fill="#b3995d" stroke="#ffffff" stroke-width="0.75"/><text x="8" y="11" font-size="7.5" font-family="monospace" font-weight="bold" text-anchor="middle" fill="#ffffff">SF</text></svg>',
-    "rams": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#003594" rx="2"/><path d="M3,5 C7,1 13,3 13,8 C13,11 10,13 8,11 C9,9 11,8 10,5" fill="none" stroke="#ffa300" stroke-width="2.5"/></svg>',
-    "seahawks": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#002244" rx="2"/><path d="M2,7 C4,5 12,5 14,8 C11,10 6,10 2,7" fill="#69be28"/><circle cx="10" cy="7" r="1.2" fill="#ffffff"/><circle cx="10.5" cy="7" r="0.6" fill="#002244"/></svg>',
-    "cardinals": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#97233f" rx="2"/><path d="M2,6 C4,4 10,4 12,6 C10,9 12,12 12,12 C10,12 6,11 2,6" fill="#ffffff"/><polygon points="9,7 13,8 9,10" fill="#ffb612"/></svg>',
-    "dolphins": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#008e97" rx="2"/><circle cx="8" cy="8" r="5" fill="#fc4c02"/><path d="M3,10 C5,7 10,5 14,8 C11,9 8,11 3,10" fill="#ffffff"/><circle cx="11" cy="7" r="0.8" fill="#fc4c02"/></svg>',
+# Teletext team badges: nickname -> (abbreviation, primary color).
+# Rendered as a solid color tile with the monospace abbreviation, matching the
+# retro teletext score-page aesthetic rather than reproducing real team logos.
+TEAM_BADGES = {
+    "cowboys": ("DAL", "#002244"),
+    "packers": ("GB", "#203731"),
+    "steelers": ("PIT", "#ffb612"),
+    "chiefs": ("KC", "#e31837"),
+    "raiders": ("LV", "#101820"),
+    "bills": ("BUF", "#00338d"),
+    "ravens": ("BAL", "#241773"),
+    "texans": ("HOU", "#03202f"),
+    "broncos": ("DEN", "#0c2340"),
+    "chargers": ("LAC", "#0080c6"),
+    "patriots": ("NE", "#002244"),
+    "bengals": ("CIN", "#fb4f14"),
+    "browns": ("CLE", "#311d00"),
+    "jaguars": ("JAX", "#006778"),
+    "colts": ("IND", "#002c5f"),
+    "titans": ("TEN", "#0c2340"),
+    "jets": ("NYJ", "#125740"),
+    "giants": ("NYG", "#0b2265"),
+    "eagles": ("PHI", "#004c54"),
+    "lions": ("DET", "#0076b6"),
+    "vikings": ("MIN", "#4f2683"),
+    "bears": ("CHI", "#0b162a"),
+    "commanders": ("WAS", "#5a1414"),
+    "buccaneers": ("TB", "#d50a0a"),
+    "falcons": ("ATL", "#a71930"),
+    "panthers": ("CAR", "#0085ca"),
+    "saints": ("NO", "#101820"),
+    "49ers": ("SF", "#aa0000"),
+    "rams": ("LAR", "#003594"),
+    "seahawks": ("SEA", "#002244"),
+    "cardinals": ("ARI", "#97233f"),
+    "dolphins": ("MIA", "#008e97"),
 }
 
 
-def get_team_logo(team_name: str | None) -> str:
-    """Resolve high-fidelity teletext styled inline SVG team logo.
+def _badge_text_color(bg_hex: str) -> str:
+    """Pick black or white text for legibility against the badge color."""
+    r, g, b = (int(bg_hex[i : i + 2], 16) for i in (1, 3, 5))
+    luminance = 0.299 * r + 0.587 * g + 0.114 * b
+    return "#101820" if luminance > 150 else "#ffffff"
 
-    Matches case-insensitively using simple substring matching to ensure
-    complete resilience across full names and abbreviations.
+
+def _badge_svg(abbr: str, bg_hex: str) -> str:
+    """Build a teletext badge: solid color tile + monospace abbreviation."""
+    fg = _badge_text_color(bg_hex)
+    return (
+        '<svg class="ttx-logo" viewBox="0 0 24 16" xmlns="http://www.w3.org/2000/svg">'
+        f'<rect width="24" height="16" rx="2" fill="{bg_hex}"/>'
+        '<text x="12" y="11.5" font-size="8" font-family="monospace" '
+        f'font-weight="bold" text-anchor="middle" fill="{fg}">{abbr}</text>'
+        "</svg>"
+    )
+
+
+def _fallback_abbr(team_name: str) -> str:
+    """Derive a 2-3 letter abbreviation for teams not in the badge table."""
+    words = team_name.split()
+    if len(words) >= 2:
+        return "".join(w[0] for w in words[:3]).upper()
+    return team_name[:3].upper()
+
+
+def get_team_logo(team_name: str | None) -> str:
+    """Resolve a teletext-style team badge as an inline SVG.
+
+    Matches case-insensitively via substring matching so full names and
+    abbreviations both resolve. Unknown teams get a neutral badge built from
+    their initials.
     """
     if not team_name:
         return ""
     name_lower = team_name.lower()
-    for key, svg in TEAM_LOGOS.items():
+    for key, (abbr, color) in TEAM_BADGES.items():
         if key in name_lower:
-            return svg
-    # Robust fallback: striped green and blue retro block
-    return (
-        '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">'
-        '<rect width="8" height="16" fill="#00ff00"/>'
-        '<rect x="8" width="8" height="16" fill="#00aaff"/>'
-        "</svg>"
-    )
+            return _badge_svg(abbr, color)
+    return _badge_svg(_fallback_abbr(team_name), "#555555")
 
 
 @app.template_filter("team_logo")

--- a/frontend/src/app.py
+++ b/frontend/src/app.py
@@ -66,6 +66,74 @@ def _fetch_playoff_bracket() -> dict[str, Any] | None:
     return None
 
 
+# Retro Teletext Team Logos Database
+TEAM_LOGOS = {
+    "cowboys": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#002244" rx="2"/><polygon points="8,2 10,6 15,6 11,9 13,14 8,11 3,14 5,9 1,6 6,6" fill="#ffffff"/></svg>',
+    "packers": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#183028" rx="2"/><circle cx="8" cy="8" r="6" fill="#ffb612"/><circle cx="8" cy="8" r="4.5" fill="#183028"/><rect x="8" y="7.5" width="4" height="2" fill="#ffb612"/><rect x="7" y="6" width="2.5" height="4" fill="#183028"/><rect x="8.5" y="6" width="2" height="2" fill="#ffb612"/></svg>',
+    "steelers": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#101820" rx="2"/><path d="M8,1 Q8,4 11,4 Q8,4 8,7 Q8,4 5,4 Q8,4 8,1" fill="#ffb612"/><path d="M12,7 Q12,10 15,10 Q12,10 12,13 Q12,10 9,10 Q12,10 12,7" fill="#c60c30"/><path d="M4,7 Q4,10 7,10 Q4,10 4,13 Q4,10 1,10 Q4,10 4,7" fill="#00539b"/></svg>',
+    "chiefs": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#e31837" rx="2"/><polygon points="8,1 15,6 11,14 5,14 1,6" fill="#ffffff"/><text x="8" y="11" font-size="7" font-family="monospace" font-weight="bold" text-anchor="middle" fill="#e31837">KC</text></svg>',
+    "raiders": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#101820" rx="2"/><polygon points="2,2 14,2 12,11 8,15 4,11" fill="#a5acaf"/><polygon points="3.5,3 12.5,3 10.5,10.5 8,13.5 5.5,10.5" fill="#101820"/><rect x="5" y="5" width="2" height="2" fill="#a5acaf"/><rect x="9" y="5" width="2" height="2" fill="#a5acaf"/><rect x="6" y="8" width="4" height="2.5" fill="#a5acaf"/></svg>',
+    "bills": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#00338d" rx="2"/><path d="M2,8 C4,5 12,5 14,8 C11,11 5,11 2,8" fill="#ffffff"/><rect x="2" y="7" width="12" height="2" fill="#c60c30" transform="rotate(15 8 8)"/></svg>',
+    "ravens": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#241773" rx="2"/><path d="M2,6 C4,4 12,4 14,7 C11,11 6,10 2,6" fill="#101820"/><circle cx="10" cy="6.5" r="1" fill="#ffb612"/><polygon points="2,6 6,7 2,8" fill="#ffb612"/></svg>',
+    "texans": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#03202f" rx="2"/><rect x="1" y="2" width="7" height="12" fill="#ffffff" rx="1"/><rect x="8" y="2" width="7" height="12" fill="#a71930" rx="1"/><polygon points="3,5 8,8 13,5 8,11" fill="#03202f"/><circle cx="8" cy="8" r="1.5" fill="#ffffff"/></svg>',
+    "broncos": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#0c2340" rx="2"/><path d="M2,12 C4,10 6,4 13,5 C10,6 11,9 14,9 C10,10 8,12 2,12" fill="#fc4c02"/><path d="M3,11 C5,10 7,6 12,7 C10,8 10,10 13,10 C10,11 8,11 3,11" fill="#ffffff"/><circle cx="10" cy="8" r="0.8" fill="#fc4c02"/></svg>',
+    "chargers": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#0080c6" rx="2"/><polygon points="12,2 5,9 8,9 3,14 11,6 8,6" fill="#ffc20e" stroke="#ffffff" stroke-width="0.75"/></svg>',
+    "patriots": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#002244" rx="2"/><path d="M2,5 Q8,2 14,6 Q10,10 2,5" fill="#a5acaf"/><path d="M2,5 Q8,2 14,6 Q10,8 2,9" fill="#c60c30"/><circle cx="5" cy="5" r="1" fill="#ffffff"/></svg>',
+    "bengals": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#fb4f14" rx="2"/><line x1="0" y1="3" x2="6" y2="5" stroke="#101820" stroke-width="1.5"/><line x1="16" y1="6" x2="10" y2="8" stroke="#101820" stroke-width="1.5"/><line x1="0" y1="9" x2="8" y2="10" stroke="#101820" stroke-width="1.5"/><line x1="16" y1="12" x2="8" y2="13" stroke="#101820" stroke-width="1.5"/></svg>',
+    "browns": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#eb3300" rx="2"/><rect x="6" width="4" height="16" fill="#ffffff"/><rect x="7" width="2" height="16" fill="#311d00"/></svg>',
+    "jaguars": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#006778" rx="2"/><circle cx="8" cy="8" r="5" fill="#d7a22a"/><rect x="7" y="5" width="2" height="2" fill="#000000"/><rect x="5" y="8" width="2" height="2" fill="#000000"/><rect x="9" y="8" width="2" height="2" fill="#000000"/><rect x="7" y="10" width="2" height="2" fill="#000000"/></svg>',
+    "colts": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#002c5f" rx="2"/><path d="M4,4 L4,9 C4,12 12,12 12,9 L12,4" fill="none" stroke="#ffffff" stroke-width="2.5"/><circle cx="5.5" cy="5" r="0.75" fill="#002c5f"/><circle cx="10.5" cy="5" r="0.75" fill="#002c5f"/><circle cx="5.5" cy="8" r="0.75" fill="#002c5f"/><circle cx="10.5" cy="8" r="0.75" fill="#002c5f"/><circle cx="8" cy="10.5" r="0.75" fill="#002c5f"/></svg>',
+    "titans": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#4b92db" rx="2"/><circle cx="8" cy="8" r="5" fill="#c60c30"/><polygon points="8,1 12,6 8,11 4,6" fill="#002244"/><rect x="7" y="4" width="2" height="6" fill="#ffffff"/><rect x="5" y="4" width="6" height="2" fill="#ffffff"/></svg>',
+    "jets": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#125740" rx="2"/><ellipse cx="8" cy="8" rx="7" ry="5" fill="none" stroke="#ffffff" stroke-width="1.5"/><text x="8" y="10.5" font-size="6.5" font-family="monospace" font-weight="bold" text-anchor="middle" fill="#ffffff">JETS</text></svg>',
+    "giants": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#0b2265" rx="2"/><text x="8" y="11" font-size="8.5" font-family="monospace" font-weight="bold" text-anchor="middle" fill="#ffffff">ny</text></svg>',
+    "eagles": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#004c54" rx="2"/><path d="M2,8 C4,4 12,4 14,5 C10,7 12,10 14,10 C10,11 6,12 2,8" fill="#a5acaf"/><path d="M3,8 C5,5 11,5 13,6 C9,8 11,10 13,10 C9,11 6,11 3,8" fill="#ffffff"/></svg>',
+    "lions": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#0076b6" rx="2"/><path d="M3,11 C5,8 6,4 13,5 C11,7 13,9 14,11 C10,12 6,12 3,11" fill="#b0b7bc"/><circle cx="5" cy="11" r="1.5" fill="#0076b6"/></svg>',
+    "vikings": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#4f2683" rx="2"/><path d="M3,5 C5,5 13,3 12,8 C11,11 6,13 4,9" fill="#ffffff"/><path d="M12,3 C10,5 11,8 12,8 C13,8 14,5 12,3" fill="#ffb612"/></svg>',
+    "bears": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#0b2265" rx="2"/><circle cx="8" cy="8" r="6" fill="#c83803"/><circle cx="8" cy="8" r="4" fill="#0b2265"/><rect x="7" y="5" width="6" height="6" fill="#0b2265"/><rect x="8.5" y="4" width="2.5" height="2" fill="#c83803"/><rect x="8.5" y="10" width="2.5" height="2" fill="#c83803"/></svg>',
+    "commanders": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#5a1414" rx="2"/><text x="8" y="12" font-size="12" font-family="monospace" font-weight="bold" text-anchor="middle" fill="#ffc20e">W</text></svg>',
+    "buccaneers": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#3a3a3a" rx="2"/><rect x="2" y="2" width="12" height="10" fill="#d50a0a"/><circle cx="8" cy="6" r="2" fill="#ffffff"/><line x1="5" y1="9" x2="11" y2="9" stroke="#ffffff" stroke-width="1.5"/></svg>',
+    "falcons": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#000000" rx="2"/><polygon points="2,4 14,4 12,8 8,12 4,8" fill="#a71930"/><polygon points="4,4 12,4 10,7 8,9 6,7" fill="#ffffff"/></svg>',
+    "panthers": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#101820" rx="2"/><path d="M2,6 C4,4 12,4 14,7 C10,9 12,12 14,12 C10,13 6,11 2,6" fill="#0085ca"/><circle cx="10" cy="7" r="1" fill="#ffffff"/></svg>',
+    "saints": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#101820" rx="2"/><path d="M8,2 C8,5 11,8 11,10 C11,12 9,13 8,13 C7,13 5,12 5,10 C5,8 8,5 8,2" fill="#d3bc8d"/><line x1="4" y1="10" x2="12" y2="10" stroke="#d3bc8d" stroke-width="2"/></svg>',
+    "49ers": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#aa0000" rx="2"/><ellipse cx="8" cy="8" rx="7" ry="5" fill="#b3995d" stroke="#ffffff" stroke-width="0.75"/><text x="8" y="11" font-size="7.5" font-family="monospace" font-weight="bold" text-anchor="middle" fill="#ffffff">SF</text></svg>',
+    "rams": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#003594" rx="2"/><path d="M3,5 C7,1 13,3 13,8 C13,11 10,13 8,11 C9,9 11,8 10,5" fill="none" stroke="#ffa300" stroke-width="2.5"/></svg>',
+    "seahawks": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#002244" rx="2"/><path d="M2,7 C4,5 12,5 14,8 C11,10 6,10 2,7" fill="#69be28"/><circle cx="10" cy="7" r="1.2" fill="#ffffff"/><circle cx="10.5" cy="7" r="0.6" fill="#002244"/></svg>',
+    "cardinals": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#97233f" rx="2"/><path d="M2,6 C4,4 10,4 12,6 C10,9 12,12 12,12 C10,12 6,11 2,6" fill="#ffffff"/><polygon points="9,7 13,8 9,10" fill="#ffb612"/></svg>',
+    "dolphins": '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16" fill="#008e97" rx="2"/><circle cx="8" cy="8" r="5" fill="#fc4c02"/><path d="M3,10 C5,7 10,5 14,8 C11,9 8,11 3,10" fill="#ffffff"/><circle cx="11" cy="7" r="0.8" fill="#fc4c02"/></svg>',
+}
+
+
+def get_team_logo(team_name: str | None) -> str:
+    """Resolve high-fidelity teletext styled inline SVG team logo.
+
+    Matches case-insensitively using simple substring matching to ensure
+    complete resilience across full names and abbreviations.
+    """
+    if not team_name:
+        return ""
+    name_lower = team_name.lower()
+    for key, svg in TEAM_LOGOS.items():
+        if key in name_lower:
+            return svg
+    # Robust fallback: striped green and blue retro block
+    return (
+        '<svg class="ttx-logo" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">'
+        '<rect width="8" height="16" fill="#00ff00"/>'
+        '<rect x="8" width="8" height="16" fill="#00aaff"/>'
+        "</svg>"
+    )
+
+
+@app.template_filter("team_logo")
+def team_logo_filter(team_name):
+    return get_team_logo(team_name)
+
+
+@app.context_processor
+def inject_team_logo():
+    return dict(team_logo=get_team_logo)
+
+
 @app.route("/")
 def home():
     try:

--- a/frontend/src/static/teletext.css
+++ b/frontend/src/static/teletext.css
@@ -479,7 +479,7 @@ body {
 
 .ttx-logo {
     display: inline-block;
-    width: 16px;
+    width: 24px;
     height: 16px;
     vertical-align: middle;
     margin-right: 8px;

--- a/frontend/src/static/teletext.css
+++ b/frontend/src/static/teletext.css
@@ -186,6 +186,8 @@ body {
 
 .ttx-team {
     color: var(--fg);
+    display: inline-flex;
+    align-items: center;
 }
 
 .ttx-record {
@@ -473,4 +475,13 @@ body {
     color: #666;
     font-size: 10px;
     padding: 2px 0;
+}
+
+.ttx-logo {
+    display: inline-block;
+    width: 16px;
+    height: 16px;
+    vertical-align: middle;
+    margin-right: 8px;
+    flex-shrink: 0;
 }

--- a/frontend/src/templates/home.html
+++ b/frontend/src/templates/home.html
@@ -46,8 +46,8 @@
             live_games %}
             <li class="ttx-item">
               <div class="ttx-teams" aria-label="Teams">
-                <div class="ttx-team ttx-team-a">{{ game.team_a }}</div>
-                <div class="ttx-team ttx-team-b">{{ game.team_b }}</div>
+                <div class="ttx-team ttx-team-a">{{ team_logo(game.team_a) | safe }}{{ game.team_a }}</div>
+                <div class="ttx-team ttx-team-b">{{ team_logo(game.team_b) | safe }}{{ game.team_b }}</div>
               </div>
               <div class="ttx-live-meta" aria-label="Score and game clock">
                 <span class="ttx-score">
@@ -79,12 +79,12 @@
                 <div
                   class="ttx-team ttx-team-a {% if game.status == 'final' and game.score_a is not none and game.score_b is not none and game.score_a > game.score_b %}ttx-winner{% elif game.status == 'final' and game.score_a is not none and game.score_b is not none and game.score_a == game.score_b %}ttx-tie{% endif %}"
                 >
-                  {{ game.team_a }}
+                  {{ team_logo(game.team_a) | safe }}{{ game.team_a }}
                 </div>
                 <div
                   class="ttx-team ttx-team-b {% if game.status == 'final' and game.score_a is not none and game.score_b is not none and game.score_b > game.score_a %}ttx-winner{% elif game.status == 'final' and game.score_a is not none and game.score_b is not none and game.score_a == game.score_b %}ttx-tie{% endif %}"
                 >
-                  {{ game.team_b }}
+                  {{ team_logo(game.team_b) | safe }}{{ game.team_b }}
                 </div>
               </div>
               {% if game.status == 'final' %}
@@ -142,11 +142,13 @@
                   <div class="ttx-bracket-matchup">
                     <div class="ttx-bracket-team {% if game.winner == game.away_team %}ttx-winner{% endif %}">
                       {% if game.away_seed %}<span class="ttx-seed-num">({{ game.away_seed }})</span>{% endif %}
+                      {{ team_logo(game.away_team) | safe }}
                       <span class="ttx-team-name">{{ game.away_team }}</span>
                       <span class="ttx-game-score">{{ game.away_score if game.away_score is not none else '-' }}</span>
                     </div>
                     <div class="ttx-bracket-team {% if game.winner == game.home_team %}ttx-winner{% endif %}">
                       {% if game.home_seed %}<span class="ttx-seed-num">({{ game.home_seed }})</span>{% endif %}
+                      {{ team_logo(game.home_team) | safe }}
                       <span class="ttx-team-name">{{ game.home_team }}</span>
                       <span class="ttx-game-score">{{ game.home_score if game.home_score is not none else '-' }}</span>
                     </div>
@@ -164,11 +166,13 @@
               <div class="ttx-bracket-game ttx-superbowl-game">
                 <div class="ttx-bracket-matchup">
                   <div class="ttx-bracket-team {% if game.winner == game.away_team %}ttx-winner{% endif %}">
+                    {{ team_logo(game.away_team) | safe }}
                     <span class="ttx-team-name">{{ game.away_team }}</span>
                     <span class="ttx-game-score">{{ game.away_score if game.away_score is not none else '-' }}</span>
                   </div>
                   <div class="ttx-vs">vs</div>
                   <div class="ttx-bracket-team {% if game.winner == game.home_team %}ttx-winner{% endif %}">
+                    {{ team_logo(game.home_team) | safe }}
                     <span class="ttx-team-name">{{ game.home_team }}</span>
                     <span class="ttx-game-score">{{ game.home_score if game.home_score is not none else '-' }}</span>
                   </div>
@@ -196,11 +200,13 @@
                   <div class="ttx-bracket-matchup">
                     <div class="ttx-bracket-team {% if game.winner == game.away_team %}ttx-winner{% endif %}">
                       {% if game.away_seed %}<span class="ttx-seed-num">({{ game.away_seed }})</span>{% endif %}
+                      {{ team_logo(game.away_team) | safe }}
                       <span class="ttx-team-name">{{ game.away_team }}</span>
                       <span class="ttx-game-score">{{ game.away_score if game.away_score is not none else '-' }}</span>
                     </div>
                     <div class="ttx-bracket-team {% if game.winner == game.home_team %}ttx-winner{% endif %}">
                       {% if game.home_seed %}<span class="ttx-seed-num">({{ game.home_seed }})</span>{% endif %}
+                      {{ team_logo(game.home_team) | safe }}
                       <span class="ttx-team-name">{{ game.home_team }}</span>
                       <span class="ttx-game-score">{{ game.home_score if game.home_score is not none else '-' }}</span>
                     </div>
@@ -221,7 +227,7 @@
           <ul class="ttx-list">
             {% for s in teams %}
             <li class="ttx-item">
-              <div class="ttx-team">{{ s.team }}</div>
+              <div class="ttx-team">{{ team_logo(s.team) | safe }}{{ s.team }}</div>
               {% set has_ties = s.ties is defined and s.ties is not none %}
               <div
                 class="ttx-record"

--- a/frontend/src/utest/test_app.py
+++ b/frontend/src/utest/test_app.py
@@ -451,23 +451,66 @@ def test_get_team_logo_resolver():
     """Test get_team_logo function resolves team logos case-insensitively and provides fallback."""
     from ..app import get_team_logo
 
-    # Verify known teams are resolved case-insensitively
+    # Verify known teams resolve to a color tile with their abbreviation
     cowboys_svg = get_team_logo("Dallas Cowboys")
     assert "ttx-logo" in cowboys_svg
-    assert "cowboys" in cowboys_svg.lower() or "#002244" in cowboys_svg
+    assert ">DAL<" in cowboys_svg
+    assert "#002244" in cowboys_svg
 
     dolphins_svg = get_team_logo("Miami Dolphins")
     assert "ttx-logo" in dolphins_svg
+    assert ">MIA<" in dolphins_svg
     assert "#008e97" in dolphins_svg
 
-    # Verify fallback for unknown team
+    # Verify fallback for unknown team: neutral tile with derived initials
     unknown_svg = get_team_logo("Unknown Team")
     assert "ttx-logo" in unknown_svg
-    assert "#00ff00" in unknown_svg
-    assert "#00aaff" in unknown_svg
+    assert ">UT<" in unknown_svg
+    assert "#555555" in unknown_svg
 
     # None handling
     assert get_team_logo(None) == ""
+
+
+def test_badge_text_color_contrast():
+    """Badge text color flips to stay legible against light vs dark tiles."""
+    from ..app import _badge_text_color
+
+    # Light backgrounds get dark text (e.g. Steelers gold).
+    assert _badge_text_color("#ffb612") == "#101820"
+    assert _badge_text_color("#ffffff") == "#101820"
+    # Dark backgrounds get white text (e.g. Cowboys navy).
+    assert _badge_text_color("#002244") == "#ffffff"
+    assert _badge_text_color("#000000") == "#ffffff"
+
+
+def test_all_known_teams_resolve_uniquely():
+    """Every team in the table resolves to its own badge; abbreviations are unique."""
+    from ..app import TEAM_BADGES, get_team_logo
+
+    for key, (abbr, color) in TEAM_BADGES.items():
+        # A realistic full name containing the nickname must resolve to this team,
+        # i.e. no earlier substring match shadows it.
+        svg = get_team_logo(f"Some City {key.title()}")
+        assert "ttx-logo" in svg
+        assert f">{abbr}<" in svg
+        assert color in svg
+
+    abbrs = [abbr for abbr, _ in TEAM_BADGES.values()]
+    assert len(set(abbrs)) == len(abbrs), "duplicate team abbreviations"
+
+
+def test_fallback_abbr_derivation():
+    """Unknown teams get a neutral tile with initials derived from the name."""
+    from ..app import get_team_logo
+
+    multi = get_team_logo("Birmingham Iron Squad")
+    assert ">BIS<" in multi
+    assert "#555555" in multi
+
+    single = get_team_logo("Spartans")
+    assert ">SPA<" in single
+    assert "#555555" in single
 
 
 if __name__ == "__main__":

--- a/frontend/src/utest/test_app.py
+++ b/frontend/src/utest/test_app.py
@@ -447,5 +447,28 @@ def test_standings_panel_shown_in_regular_season(mock_get, client):
     assert "Playoff Bracket" not in text
 
 
+def test_get_team_logo_resolver():
+    """Test get_team_logo function resolves team logos case-insensitively and provides fallback."""
+    from ..app import get_team_logo
+
+    # Verify known teams are resolved case-insensitively
+    cowboys_svg = get_team_logo("Dallas Cowboys")
+    assert "ttx-logo" in cowboys_svg
+    assert "cowboys" in cowboys_svg.lower() or "#002244" in cowboys_svg
+
+    dolphins_svg = get_team_logo("Miami Dolphins")
+    assert "ttx-logo" in dolphins_svg
+    assert "#008e97" in dolphins_svg
+
+    # Verify fallback for unknown team
+    unknown_svg = get_team_logo("Unknown Team")
+    assert "ttx-logo" in unknown_svg
+    assert "#00ff00" in unknown_svg
+    assert "#00aaff" in unknown_svg
+
+    # None handling
+    assert get_team_logo(None) == ""
+
+
 if __name__ == "__main__":
     pytest.main()

--- a/justfile
+++ b/justfile
@@ -110,12 +110,19 @@ ci-e2e: lint-e2e ty-e2e test-e2e
 
 # --- Mock Mode ---
 
-# Start services with mock ESPN data
+# Start services with mock ESPN data using containers
 mock-up:
     MOCK_ESPN=true {{ docker }} compose up -d
     @echo "✅ Mock services started!"
     @echo "💡 Backend: http://localhost:8000 (fixture data)"
     @echo "💡 Frontend: http://localhost:5000"
+
+# Start services locally without containers using the virtual environment
+local-mock-up:
+    @echo "🚀 Starting backend on http://localhost:8000..."
+    @MOCK_ESPN=true PYTHONPATH=backend/src {{ python }} -m uvicorn main:app --port 8000 & \
+    echo "🚀 Starting frontend on http://localhost:5000..." && \
+    BACKEND_URL=http://localhost:8000 {{ python }} frontend/src/app.py
 
 # Run tests in mock mode
 test-mock:


### PR DESCRIPTION
## What
Adds per-team teletext-style badges next to team names across the scoreboard, schedule, standings, and playoff bracket, rendered as solid color tiles with each team's monospace abbreviation.

## Why
The app uses a retro teletext / monospace aesthetic. Team identity in the lists was text-only; small badges make games and standings easier to scan. An initial approach drew detailed SVG logo reproductions, but those looked rough at 16px and clashed with the teletext look — abbreviation tiles read cleanly at small size and avoid reproducing trademarked marks.

## Changes
- **`frontend/src/app.py`** — `get_team_logo()` resolver returning an inline SVG badge:
  - `TEAM_BADGES` table mapping all 32 nicknames → (abbreviation, primary color).
  - `_badge_svg()` builds a 24×16 color tile with the monospace abbreviation.
  - `_badge_text_color()` picks black/white text by luminance for legibility (e.g. dark text on Steelers gold).
  - `_fallback_abbr()` derives initials for unlisted teams onto a neutral tile.
  - Exposed to templates via a `team_logo` filter and context processor.
- **`frontend/src/templates/home.html`** — render `team_logo(...)` before team names in live, schedule, standings, and bracket sections.
- **`frontend/src/static/teletext.css`** — `.ttx-logo` tile styling (24×16 to fit 3-letter abbreviations).
- **`frontend/src/utest/test_app.py`** — tests for the resolver, the luminance contrast picker, unique resolution of all 32 teams (substring-collision guard), and fallback initials.
- **`justfile`** — add `local-mock-up` recipe to run backend + frontend locally (no containers) with mock ESPN data.
- **`.gitignore`** — ignore `.antigravitycli/`.

## Testing
- `just ci` green (lint, format, type-check, unit tests); frontend suite 15 passed.
- E2E suite 76/76 passed (chromium + api, mock mode).
- Manual localhost check: all team rows render the new 24×16 badges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)